### PR TITLE
Replace obsolete Travis build with pinned read-only CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,24 @@
+name: Check
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: macos-15
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - run: make check
+      - if: always()
+        run: make clean

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 build/*
 build_products
+.derived-data/
 
 *.pbxuser
 !default.pbxuser

--- a/FSExampleOAuth/FSExampleOAuth.xcodeproj/xcshareddata/xcschemes/FSExampleOAuth.xcscheme
+++ b/FSExampleOAuth/FSExampleOAuth.xcodeproj/xcshareddata/xcschemes/FSExampleOAuth.xcscheme
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0800"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F10698A01729B6F50053AF0B"
+               BuildableName = "FSExampleOAuth.app"
+               BlueprintName = "FSExampleOAuth"
+               ReferencedContainer = "container:FSExampleOAuth.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F10698A01729B6F50053AF0B"
+            BuildableName = "FSExampleOAuth.app"
+            BlueprintName = "FSExampleOAuth"
+            ReferencedContainer = "container:FSExampleOAuth.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F10698A01729B6F50053AF0B"
+            BuildableName = "FSExampleOAuth.app"
+            BlueprintName = "FSExampleOAuth"
+            ReferencedContainer = "container:FSExampleOAuth.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FSExampleOAuth/FSExampleOAuth/FSAppDelegate.m
+++ b/FSExampleOAuth/FSExampleOAuth/FSAppDelegate.m
@@ -26,7 +26,7 @@
     return YES;
 }
 
-- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray * _Nullable))restorationHandler
+- (BOOL)application:(UIApplication *)application continueUserActivity:(NSUserActivity *)userActivity restorationHandler:(void (^)(NSArray<id<UIUserActivityRestoring>> * _Nullable restorableObjects))restorationHandler
 {
     BOOL didHandle = NO;
     if ([userActivity.activityType isEqual:NSUserActivityTypeBrowsingWeb]) {

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+PROJECT := FSExampleOAuth/FSExampleOAuth.xcodeproj
+SCHEME := FSExampleOAuth
+DERIVED_DATA ?= $(CURDIR)/.derived-data
+XCODE_FLAGS := \
+	-project "$(PROJECT)" \
+	-scheme "$(SCHEME)" \
+	-configuration Debug \
+	-sdk iphonesimulator \
+	-destination "generic/platform=iOS Simulator" \
+	-derivedDataPath "$(DERIVED_DATA)" \
+	IPHONEOS_DEPLOYMENT_TARGET=12.0 \
+	PRODUCT_BUNDLE_IDENTIFIER=com.foursquare.FSExampleOAuth \
+	CODE_SIGNING_ALLOWED=NO \
+	CODE_SIGNING_REQUIRED=NO \
+	CODE_SIGN_IDENTITY=
+
+.PHONY: check test analyze build clean
+
+check: test analyze build
+
+test:
+	python3 -m unittest discover -s tests -v
+
+analyze:
+	xcodebuild analyze $(XCODE_FLAGS)
+
+build:
+	xcodebuild build $(XCODE_FLAGS)
+
+clean:
+	rm -rf "$(DERIVED_DATA)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 foursquare-ios-oauth
 ====================
 
+> **Legacy security notice:** This is a legacy sample retained for historical
+> reference. Do not use it for a new production integration. Its optional
+> code-to-token helper accepts a client secret in the app, predates PKCE and a
+> state parameter, uses legacy callback handling, and displays authorization
+> codes and tokens in the sample UI. Keep client secrets and token exchange on
+> a trusted server. The repository CI only performs static analysis and an
+> unsigned simulator build; it never contacts Foursquare.
+
 Foursquare native authentication makes it easier for your app's users to connect with Foursquare. Unlike web-based OAuth, native authentication re-uses the Foursquare app's user credentials, saving users the hassle of re-logging in to Foursquare within your app.
 
 This repo includes a helper class (`FSOAuth`) that can be used as-is in your own app. It also includes a simple test application as an example of how to use the class.

--- a/tests/test_repository_policy.py
+++ b/tests/test_repository_policy.py
@@ -1,0 +1,88 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "check.yml"
+MAKEFILE = ROOT / "Makefile"
+README = ROOT / "README.md"
+APP_DELEGATE = ROOT / "FSExampleOAuth" / "FSExampleOAuth" / "FSAppDelegate.m"
+
+
+class RepositoryPolicyTests(unittest.TestCase):
+    def test_obsolete_travis_configuration_is_removed(self):
+        self.assertFalse((ROOT / ".travis.yml").exists())
+
+    def test_workflow_is_pinned_read_only_and_provider_free(self):
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertIn("runs-on: macos-15", workflow)
+        self.assertRegex(
+            workflow,
+            r"actions/checkout@[0-9a-f]{40}\s+# v7\.0\.0",
+        )
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("run: make check", workflow)
+
+        for forbidden in (
+            "pull_request_target",
+            "self-hosted",
+            "${{ secrets.",
+            "curl ",
+            "wget ",
+            "foursquare.com",
+            "api.foursquare.com",
+        ):
+            self.assertNotIn(forbidden, workflow)
+
+    def test_make_check_is_unsigned_isolated_and_static(self):
+        makefile = MAKEFILE.read_text(encoding="utf-8")
+
+        self.assertIn("python3 -m unittest discover -s tests -v", makefile)
+        self.assertIn("xcodebuild analyze", makefile)
+        self.assertIn("xcodebuild build", makefile)
+        self.assertIn("CODE_SIGNING_ALLOWED=NO", makefile)
+        self.assertIn("CODE_SIGNING_REQUIRED=NO", makefile)
+        self.assertIn("IPHONEOS_DEPLOYMENT_TARGET=12.0", makefile)
+        self.assertIn("PRODUCT_BUNDLE_IDENTIFIER=com.foursquare.FSExampleOAuth", makefile)
+        self.assertIn('-destination "generic/platform=iOS Simulator"', makefile)
+        self.assertIn("-derivedDataPath \"$(DERIVED_DATA)\"", makefile)
+        self.assertNotRegex(makefile, re.compile(r"\b(curl|wget)\b"))
+
+    def test_shared_scheme_is_committed(self):
+        scheme = (
+            ROOT
+            / "FSExampleOAuth"
+            / "FSExampleOAuth.xcodeproj"
+            / "xcshareddata"
+            / "xcschemes"
+            / "FSExampleOAuth.xcscheme"
+        )
+        self.assertTrue(scheme.is_file())
+
+    def test_legacy_oauth_risks_are_prominent(self):
+        readme = README.read_text(encoding="utf-8")
+
+        for warning in (
+            "legacy sample",
+            "Do not use it for a new production integration",
+            "client secret",
+            "PKCE",
+            "state parameter",
+            "never contacts Foursquare",
+        ):
+            self.assertIn(warning, readme)
+
+    def test_universal_link_callback_matches_the_current_delegate_contract(self):
+        app_delegate = APP_DELEGATE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "NSArray<id<UIUserActivityRestoring>> * _Nullable restorableObjects",
+            app_delegate,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the unusable Travis `xcode7` / iPhone 4s / iOS 8.4 job with a pinned, read-only GitHub Actions macOS check
- keep a shared Xcode scheme and run policy tests, Clang static analysis, and an unsigned simulator build without provider traffic
- document the sample's legacy OAuth risks and align the universal-link delegate callback with the current SDK contract

## Review evidence

- the original job cannot run on current infrastructure and the project only builds under current Xcode with an explicit modern simulator deployment target
- CI has `contents: read`, disables checkout credential persistence, contains no secrets, provider endpoints, downloads, signing, or self-hosted execution
- local `make check`, Actionlint, plist validation, diff validation, and redacted current/full-history Gitleaks scans passed
- no Foursquare request was made

## Residual legacy risk

The archived helper predates PKCE and OAuth state, accepts a client secret in the app, places token-exchange values in a query string, uses deprecated URL-opening APIs, and displays codes/tokens in the sample UI. It should not be used for a new production integration.
